### PR TITLE
fix(#27): Make `list-all` display only versions that have corresponding binaries available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,32 @@ jobs:
       - name: Test odo
         run: odo version
 
+  plugin_list-all_test:
+    name: list-all
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@v1
+        with:
+          asdf_branch: v0.10.2
+
+      - name: Install plugin manually
+        run: |
+          mkdir -p ~/.asdf/plugins
+          ln -snf "$(pwd)" ~/.asdf/plugins/odo
+
+      - name: Check that list-all does not include a non-installable tag
+        run: |
+          ret=$(asdf list-all odo | grep -F "2.0.0-beta-1" || echo pass)
+          if [[ "$ret" != "pass" ]]; then
+            echo "ret: $ret"
+            echo "unexpected version found: 2.0.0-beta-1, which is not installable"
+            exit 1
+          fi
+
   plugin_test_specific_version:
     name: Test installing specific version
     strategy:


### PR DESCRIPTION
## Description

This makes `asdf list-all odo` return versions that can actually be installed. Previously, it used to list all Git tags, without checking that binaries were available for such versions.
Now, it still starts with fetching all tags, but display a tag only if there is binary for it published in the Red Hat Content Gateway.

## Motivation and Context
See #27 for more context.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue). Fixes #27 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples
`asdf list-all odo`

## How Has This Been Tested?
`asdf list-all odo` no longer displays versions that have no corresponding binaries, like `2.0.0-beta-1`

```sh
asdf list-all odo | grep 2.0.0-beta-1
```

<details>
<summary>Example output:</summary>

```sh
1.0.0
1.0.1
1.0.2
1.0.3
1.1.0
1.1.1
1.1.2
1.1.3
1.2.0
1.2.1
1.2.2
1.2.3
1.2.4
1.2.5
1.2.6
2.0.0
2.0.1
2.0.2
2.0.3
2.0.4
2.0.5
2.0.6
2.0.7
2.1.0
2.2.0
2.2.1
2.2.2
2.2.3
2.2.4
2.3.0
2.3.1
2.4.0
2.4.1
2.4.2
2.4.3
2.5.0
2.5.1
3.0.0-alpha1
3.0.0-alpha2
3.0.0-alpha3
3.0.0-beta1
3.0.0-beta2
3.0.0-beta3
3.0.0-rc1
```

</details>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
