### PR TITLE
feat: Add new extension command for asdf: `asdf odo preference`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,79 @@ jobs:
             exit 1
           fi
 
+  plugin_extension_preference_tests:
+    name: asdf odo preference
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@v1
+        with:
+          asdf_branch: v0.10.2
+
+      - name: Install plugin manually
+        run: |
+          mkdir -p ~/.asdf/plugins
+          ln -snf "$(pwd)" ~/.asdf/plugins/odo
+
+      - name: Install latest odo
+        run: |
+          asdf install odo latest
+          asdf global odo latest
+
+      - name: Check that 'asdf odo preference which' works correctly even if GLOBALODOCONFIG preference is not set
+        run: |
+          unset GLOBALODOCONFIG
+          ret=$(asdf odo preference which)
+          if [[ "$ret" != "${HOME}/.config/odo/settings.yaml" ]]; then
+            echo "ret: $ret"
+            echo "unexpected output for 'asdf odo preference which'. Expected: ${HOME}/.config/odo/settings.yaml"
+            exit 1
+          fi
+
+      - name: Check that 'asdf odo preference which' works correctly if GLOBALODOCONFIG preference is set by user
+        run: |
+          export GLOBALODOCONFIG=/tmp/config/odo_settings.yaml
+          ret=$(asdf odo preference which)
+          if [[ "$ret" != "${GLOBALODOCONFIG}" ]]; then
+            echo "ret: $ret"
+            echo "unexpected output for 'asdf odo preference which'. Expected: ${GLOBALODOCONFIG}"
+            exit 1
+          fi
+
+      - name: Check that 'asdf odo preference reset' does not exit if GLOBALODOCONFIG does not exist
+        run: |
+          export GLOBALODOCONFIG=/tmp/404/some.file
+          asdf odo preference reset || exit 1
+          if [ -f "${GLOBALODOCONFIG}" ]; then
+            echo "File should still be inexistent after running 'asdf odo preference reset': ${GLOBALODOCONFIG}"
+            exit 1
+          fi
+
+      - name: Check that 'asdf odo preference reset' works correctly if GLOBALODOCONFIG preference is set by user
+        run: |
+          export GLOBALODOCONFIG=/tmp/config/odo_settings.yaml
+          mkdir -p "$(dirname "${GLOBALODOCONFIG}")"
+          cp -vr ./.github/.odo_config.yaml "${GLOBALODOCONFIG}"
+          (yes || true) | asdf odo preference reset
+          if [ -f "${GLOBALODOCONFIG}" ]; then
+            echo "File should have been removed by 'asdf odo preference reset': ${GLOBALODOCONFIG}"
+            exit 1
+          fi
+
+      - name: Check that 'asdf odo preference reset' works correctly even if GLOBALODOCONFIG preference is not set
+        run: |
+          unset GLOBALODOCONFIG
+          mkdir -p "${HOME}/.config/odo/"
+          cp -vr ./.github/.odo_config.yaml "${HOME}/.config/odo/settings.yaml"
+          (yes || true) | asdf odo preference reset
+          if [ -f "${HOME}/.config/odo/settings.yaml" ]; then
+            echo "File should have been removed by 'asdf odo preference reset': ${HOME}/.config/odo/settings.yaml"
+            exit 1
+          fi
+
   plugin_test_specific_version:
     name: Test installing specific version
     strategy:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ odo help
 Check [asdf](https://github.com/asdf-vm/asdf) README for more instructions on how to
 install & manage versions.
 
+# Additional commands
+
+This plugin defines additional `asdf` commands to provide utilities that help manage `odo`.
+
+## Preferences management
+
+This is the output of `asdf odo preference help`:
+
+```
+asdf odo preference COMMAND
+
+COMMANDS
+   which    -   Shows the path to the file where the current odo stores its settings.
+   reset    -   Resets the odo settings to their default values.
+                This essentially removes the current preferences file,
+                so subsequent odo commands can recreate it.
+   help     -   Shows this help.
+
+```
+
 # FAQ
 
 ## How do I install specific releases of odo?

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -12,7 +12,7 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 source "${plugin_dir}/lib/utils.bash"
 
 if [ "${GLOBALODOCONFIG:-}" = "" ]; then
-  export GLOBALODOCONFIG="${XDG_CONFIG_HOME:-"${HOME}/.config"}/odo/config.yaml"
+  export GLOBALODOCONFIG="${XDG_CONFIG_HOME:-"${HOME}/.config"}/odo/settings.yaml"
 fi
 
 mkdir -p "$(dirname "${GLOBALODOCONFIG}")"

--- a/bin/help.links
+++ b/bin/help.links
@@ -14,6 +14,7 @@ source "${plugin_dir}/lib/utils.bash"
 echo
 bold "$(underline "# Useful Links")"
 cat <<-EOM
+- asdf version manager: https://asdf-vm.com/manage/commands.html
 - Plugin: https://github.com/rm3l/asdf-odo
 - odo: https://odo.dev/
 - Kubernetes: https://kubernetes.io/

--- a/bin/help.links
+++ b/bin/help.links
@@ -27,3 +27,11 @@ if [[ "${ASDF_INSTALL_TYPE:-}" == "ref" ]]; then
 - Go: https://go.dev/
 EOM
 fi
+
+echo
+bold "$(underline "# Additional commands")"
+cat <<-EOM
+- asdf odo preference which: Shows the path to the file where the current odo stores its settings.
+- asdf odo preference reset: Resets the odo settings to their default values. This essentially removes the current preferences file, so the next odo command can recreate it.
+- asdf odo preference help: Shows help of this custom command.
+EOM

--- a/lib/commands/command-preference.bash
+++ b/lib/commands/command-preference.bash
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${ASDF_ODO_VERBOSE:-false}" == "true" ]]; then
+  set -x
+fi
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=../utils.bash
+source "${plugin_dir}/utils.bash"
+
+HELP="
+asdf odo preference COMMAND
+
+COMMANDS
+   which    -   Shows the path to the file where the current odo stores its settings.
+   reset    -   Resets the odo settings to their default values.
+                This essentially removes the current preferences file,
+                so subsequent odo commands can recreate it.
+   help     -   Shows this help.
+"
+
+reset() {
+  local odo_config_path=$(asdf env odo | grep GLOBALODOCONFIG | awk -F '=' '{print $2}')
+  if [ -f "$odo_config_path" ]; then
+    rm -iv "$odo_config_path"
+  else
+    echo "file not found: \"$odo_config_path\"" >&2
+  fi
+}
+
+which() {
+  asdf env odo | grep GLOBALODOCONFIG | awk -F '=' '{print $2}'
+}
+
+case "$*" in
+'reset')
+  reset
+  ;;
+
+'which')
+  which
+  ;;
+
+*)
+  echo "$HELP"
+  exit 0
+  ;;
+esac


### PR DESCRIPTION
## Description

This extends the asdf CLI itself with commands that extend odo.
Currently, a simple command for preference management is introduced, with the following capabilities:
- Display the path to the odo preferences file: `asdf odo preference which`
- Reset the odo preferences file by deleting it: `asdf odo preference reset`

Since resetting the settings file works by deleting it, a confirmation is always asked.

A breaking change is also introduced by moving the default preferences file from `${XDG_CONFIG_HOME:-"~/.config"}/odo/config.yaml` to `${XDG_CONFIG_HOME:-"~/.config"}/odo/settings.yaml`

## Motivation and Context

There is already an `odo preference` command, but this extends it a little bit via `asdf`. I personally found it practical to be able to view where my settings file was located, and also to reset if from time to time.

NOTE: Changes here might end up in the upstream `odo` repository if this makes sense, making this feature obsolete in `asdf-odo` (though it would still make sense for older versions of `odo`, should that happen).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

```sh
> asdf odo preference help                

asdf odo preference COMMAND

COMMANDS
   which    -   Shows the path to the file where the current odo stores its settings.
   reset    -   Resets the odo settings to their default values.
                This essentially removes the current preferences file,
                so subsequent odo commands can recreate it.
   help     -   Shows this help.
```

Examples:

```sh
> asdf odo preference which
/home/rm3l/.config/odo/settings.yaml
```

```sh
> GLOBALODOCONFIG=/tmp/fake_config.yaml asdf odo preference which              
/tmp/fake_config.yaml
```

```sh
> GLOBALODOCONFIG=/tmp/fake_config.yaml asdf odo preference reset              
file not found: "/tmp/fake_config.yaml"
```

```sh
> asdf odo preference reset
rm: remove regular empty file '/home/rm3l/.config/odo/settings.yaml'? y
removed '/home/rm3l/.config/odo/settings.yaml'
```

## How Has This Been Tested?

Manually and in CI

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

