### PR TITLE
refactor!: Rename `asdf odo preference` into `asdf odo settings` to avoid confusion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,8 +73,8 @@ jobs:
             exit 1
           fi
 
-  plugin_extension_preference_tests:
-    name: asdf odo preference
+  plugin_extension_settings_tests:
+    name: asdf odo settings
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -95,54 +95,54 @@ jobs:
           asdf install odo latest
           asdf global odo latest
 
-      - name: Check that 'asdf odo preference which' works correctly even if GLOBALODOCONFIG preference is not set
+      - name: Check that 'asdf odo settings which' works correctly even if GLOBALODOCONFIG settings is not set
         run: |
           unset GLOBALODOCONFIG
-          ret=$(asdf odo preference which)
+          ret=$(asdf odo settings which)
           if [[ "$ret" != "${HOME}/.config/odo/settings.yaml" ]]; then
             echo "ret: $ret"
-            echo "unexpected output for 'asdf odo preference which'. Expected: ${HOME}/.config/odo/settings.yaml"
+            echo "unexpected output for 'asdf odo settings which'. Expected: ${HOME}/.config/odo/settings.yaml"
             exit 1
           fi
 
-      - name: Check that 'asdf odo preference which' works correctly if GLOBALODOCONFIG preference is set by user
+      - name: Check that 'asdf odo settings which' works correctly if GLOBALODOCONFIG settings is set by user
         run: |
           export GLOBALODOCONFIG=/tmp/config/odo_settings.yaml
-          ret=$(asdf odo preference which)
+          ret=$(asdf odo settings which)
           if [[ "$ret" != "${GLOBALODOCONFIG}" ]]; then
             echo "ret: $ret"
-            echo "unexpected output for 'asdf odo preference which'. Expected: ${GLOBALODOCONFIG}"
+            echo "unexpected output for 'asdf odo settings which'. Expected: ${GLOBALODOCONFIG}"
             exit 1
           fi
 
-      - name: Check that 'asdf odo preference reset' does not exit if GLOBALODOCONFIG does not exist
+      - name: Check that 'asdf odo settings reset' does not exit if GLOBALODOCONFIG does not exist
         run: |
           export GLOBALODOCONFIG=/tmp/404/some.file
-          asdf odo preference reset || exit 1
+          asdf odo settings reset || exit 1
           if [ -f "${GLOBALODOCONFIG}" ]; then
-            echo "File should still be inexistent after running 'asdf odo preference reset': ${GLOBALODOCONFIG}"
+            echo "File should still be inexistent after running 'asdf odo settings reset': ${GLOBALODOCONFIG}"
             exit 1
           fi
 
-      - name: Check that 'asdf odo preference reset' works correctly if GLOBALODOCONFIG preference is set by user
+      - name: Check that 'asdf odo settings reset' works correctly if GLOBALODOCONFIG settings is set by user
         run: |
           export GLOBALODOCONFIG=/tmp/config/odo_settings.yaml
           mkdir -p "$(dirname "${GLOBALODOCONFIG}")"
           cp -vr ./.github/.odo_config.yaml "${GLOBALODOCONFIG}"
-          (yes || true) | asdf odo preference reset
+          (yes || true) | asdf odo settings reset
           if [ -f "${GLOBALODOCONFIG}" ]; then
-            echo "File should have been removed by 'asdf odo preference reset': ${GLOBALODOCONFIG}"
+            echo "File should have been removed by 'asdf odo settings reset': ${GLOBALODOCONFIG}"
             exit 1
           fi
 
-      - name: Check that 'asdf odo preference reset' works correctly even if GLOBALODOCONFIG preference is not set
+      - name: Check that 'asdf odo settings reset' works correctly even if GLOBALODOCONFIG settings is not set
         run: |
           unset GLOBALODOCONFIG
           mkdir -p "${HOME}/.config/odo/"
           cp -vr ./.github/.odo_config.yaml "${HOME}/.config/odo/settings.yaml"
-          (yes || true) | asdf odo preference reset
+          (yes || true) | asdf odo settings reset
           if [ -f "${HOME}/.config/odo/settings.yaml" ]; then
-            echo "File should have been removed by 'asdf odo preference reset': ${HOME}/.config/odo/settings.yaml"
+            echo "File should have been removed by 'asdf odo settings reset': ${HOME}/.config/odo/settings.yaml"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -69,17 +69,17 @@ install & manage versions.
 
 This plugin defines additional `asdf` commands with helpers that extend `odo`.
 
-## Preferences management
+## Settings management
 
-This is availabe via the `asdf odo preference` command:
+This is availabe via the `asdf odo settings` command:
 
 ```sh
-asdf odo preference COMMAND
+asdf odo settings COMMAND
 
 COMMANDS
    which    -   Shows the path to the file where the current odo stores its settings.
    reset    -   Resets the odo settings to their default values.
-                This essentially removes the current preferences file,
+                This essentially removes the current settings file,
                 so subsequent odo commands can recreate it.
    help     -   Shows this help.
 

--- a/bin/help.links
+++ b/bin/help.links
@@ -31,7 +31,7 @@ fi
 echo
 bold "$(underline "# Additional commands")"
 cat <<-EOM
-- asdf odo preference which: Shows the path to the file where the current odo stores its settings.
-- asdf odo preference reset: Resets the odo settings to their default values. This essentially removes the current preferences file, so the next odo command can recreate it.
-- asdf odo preference help: Shows help of this custom command.
+- asdf odo settings which: Shows the path to the file where the current odo stores its settings.
+- asdf odo settings reset: Resets the odo settings to their default values. This essentially removes the current settings file, so the next odo command can recreate it.
+- asdf odo settings help: Shows help of this custom command.
 EOM

--- a/lib/commands/command-settings.bash
+++ b/lib/commands/command-settings.bash
@@ -13,12 +13,12 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 source "${plugin_dir}/utils.bash"
 
 HELP="
-asdf odo preference COMMAND
+asdf odo settings COMMAND
 
 COMMANDS
    which    -   Shows the path to the file where the current odo stores its settings.
    reset    -   Resets the odo settings to their default values.
-                This essentially removes the current preferences file,
+                This essentially removes the current settings file,
                 so subsequent odo commands can recreate it.
    help     -   Shows this help.
 "


### PR DESCRIPTION
This is to avoid confusion with the native `odo preference` command.
